### PR TITLE
Do not save meta value if XPath field is not found.

### DIFF
--- a/includes/class-fp-pull.php
+++ b/includes/class-fp-pull.php
@@ -386,19 +386,20 @@ class FP_Pull {
 
 						if ( empty( $values ) ) {
 							$this->log( sprintf( __( 'Xpath to source field returns nothing for %s', 'feed-pull' ), sanitize_text_field( $field['source_field'] ) ), $source_feed_id, 'warning', $new_post_id );
-						} else {
-							if ( count( $values ) > 1 ) {
-								$pre_filter_meta_value = array();
-
-								foreach ( $values as $value ) {
-									$pre_filter_meta_value[] = (string) $value;
-								}
-							} else {
-								$pre_filter_meta_value = (string) $values[0];
-							}
-
-							$meta_value = apply_filters( 'fp_pre_post_meta_value', $pre_filter_meta_value, $field, $post, $source_feed_id );
+							continue;
 						}
+					
+						if ( count( $values ) > 1 ) {
+							$pre_filter_meta_value = array();
+
+							foreach ( $values as $value ) {
+								$pre_filter_meta_value[] = (string) $value;
+							}
+						} else {
+							$pre_filter_meta_value = (string) $values[0];
+						}
+
+						$meta_value = apply_filters( 'fp_pre_post_meta_value', $pre_filter_meta_value, $field, $post, $source_feed_id );
 
 						update_post_meta( $new_post_id, $field['destination_field'], $meta_value );
 					}


### PR DESCRIPTION
Meta values were being saved for every $meta_fields. If the source_field was not found then the value of the previous $meta_fields was used as the value of the post_meta.
